### PR TITLE
TASK-14: add pagination info to tasks list endpoint

### DIFF
--- a/api/schemas/task.py
+++ b/api/schemas/task.py
@@ -1,7 +1,7 @@
 """Schemas for Task model in the Spirited Todo List API."""
 
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -34,3 +34,12 @@ class TaskUpdate(BaseModel):
     title: Optional[str] = None
     description: Optional[str] = None
     priority: Optional[Priority] = None
+
+
+class TaskListResponse(BaseModel):
+    """Schema for listing tasks."""
+
+    items: List[TaskRead]
+    total: int
+    page: int
+    page_size: int


### PR DESCRIPTION
- Update the `get_tasks` function to return a tuple containing the list of tasks and the total count of tasks in the database for improved pagination.
- Modify the API response model for task listing to include pagination details (total count, current page, and page size).
- Adjust tests to validate the new response structure and ensure correct pagination behavior.